### PR TITLE
Filename of backup files should also use capital D, like export Files

### DIFF
--- a/app/src/main/java/com/faltenreich/diaguard/feature/export/job/Export.java
+++ b/app/src/main/java/com/faltenreich/diaguard/feature/export/job/Export.java
@@ -29,7 +29,7 @@ public class Export {
     private static final String TAG = Export.class.getSimpleName();
 
     public static final String BACKUP_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
-    private static final String FILE_BACKUP_1_3_PREFIX = "diaguard_backup_";
+    private static final String FILE_BACKUP_1_3_PREFIX = "Diaguard_Backup_";
     private static final String FILE_BACKUP_1_3_DATE_FORMAT = "yyyyMMddHHmmss";
 
     private static final String EXPORT_FILE_NAME_PREFIX = "Diaguard";


### PR DESCRIPTION
all Export files start with Diaguard_... The bakup file only uses lowercase chars, that is triggering my inner Monk.
And yes i know it should have been capitalized not capital