### PR TITLE
Fix import problems with backslashes in notes in backup files

### DIFF
--- a/app/src/main/java/com/faltenreich/diaguard/feature/export/job/csv/CsvImport.java
+++ b/app/src/main/java/com/faltenreich/diaguard/feature/export/job/csv/CsvImport.java
@@ -29,7 +29,7 @@ import com.faltenreich.diaguard.shared.data.database.entity.Measurement;
 import com.faltenreich.diaguard.shared.data.database.entity.Tag;
 import com.faltenreich.diaguard.shared.data.database.entity.deprecated.CategoryDeprecated;
 import com.faltenreich.diaguard.shared.data.primitive.FloatUtils;
-import com.opencsv.CSVParserBuilder;
+import com.opencsv.RFC4180ParserBuilder;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 
@@ -71,7 +71,7 @@ public class CsvImport extends AsyncTask<Void, Void, Boolean> {
     protected Boolean doInBackground(Void... params) {
         try {
             CSVReader reader = new CSVReaderBuilder(new InputStreamReader(inputStream))
-                .withCSVParser(new CSVParserBuilder()
+                .withCSVParser(new RFC4180ParserBuilder()
                     .withSeparator(CsvMeta.CSV_DELIMITER)
                     .build())
                 .build();


### PR DESCRIPTION
Swap CSVParserBuilder with RFC4180ParserBuilder in CsvImport.java, making it consistent with CSVWriter in backslash character handling.

The Problem is that the "normal" CSVParser interpretes \" in the backup files als escape character an is importing a " instead of the \ . The RFC4180Parser is more correct in the handling of escape characters.

Solution is from https://dzone.com/articles/properly-handling-backslashes-using-opencsv 

Fixes Issue #61 